### PR TITLE
Add MIT License and Babel configuration

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env"]
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Sachin Thapa
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -120,4 +120,4 @@ The following npm scripts are available:
 
 ## License
 
-This project is licensed under the ISC License. See the `package.json` file for more details.
+This project is licensed under the MIT License. See the `LICENSE` file for more details.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,10 @@
 		"nodemailer": "^6.9.16",
 		"nodemon": "^3.1.7",
 		"uuid": "^10.0.0",
-		"zod": "^3.23.8"
+		"zod": "^3.23.8",
+		"@babel/core": "^7.20.0",
+		"@babel/preset-env": "^7.20.0",
+		"@babel/cli": "^7.20.0"
 	},
 	"devDependencies": {
 		"morgan": "^1.10.0",


### PR DESCRIPTION
Add MIT License and Babel configuration to the project.

* **LICENSE**: Add MIT License text to the repository.
* **.babelrc**: Add Babel configuration with presets for `@babel/preset-env`.
* **package.json**: Add Babel dependencies: `@babel/core`, `@babel/preset-env`, `@babel/cli`.
* **README.md**: Update to mention the MIT License instead of the ISC License.

